### PR TITLE
Add dw stats

### DIFF
--- a/src/components/BlackHoleStats.tsx
+++ b/src/components/BlackHoleStats.tsx
@@ -57,8 +57,8 @@ export const BlackHoleStats = ({ props }) => {
       <p>BH:</p>
       <p>Dur: {BH_DURATION(bhDurationStones, bhDurationSubstat, bhPerk)}</p>
       <p>CD: {BH_COOLDOWN}</p>
-      <p>Wave Time: {BlackHoleStats.totalWavesTime.toLocaleString('en-US', { maximumSignificantDigits: 10 })}</p>
-      <p>Uptime: {BlackHoleStats.adjustedUptimeBH.toLocaleString('en-US', { maximumSignificantDigits: 10 })}</p>
+      <p>Wave Time: {BlackHoleStats.totalWavesTime.toLocaleString('en-US', { maximumSignificantDigits: 7 })}</p>
+      <p>Uptime: {BlackHoleStats.adjustedUptimeBH.toLocaleString('en-US', { maximumSignificantDigits: 7 })}</p>
       <p>Perma?: {BlackHoleStats.isPermanentBH ? 'Yes' : 'No'}</p>
     </>
   );

--- a/src/components/Calculator.scss
+++ b/src/components/Calculator.scss
@@ -12,6 +12,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: flex-start;
+    flex-wrap: wrap;
     p {
       margin: 5px;
       padding: 5px 10px 5px 0px;

--- a/src/components/DeathWaveStats.tsx
+++ b/src/components/DeathWaveStats.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from 'react';
+import { getInGameWaveTime } from '../utils/waveDuration';
+
+export const DeathWaveStats = ({ props }) => {
+
+  const {
+    wavesToTest,
+    packageCount,
+    DW_COOLDOWN,
+    DW_DURATION,
+    DEATH_WAVE_INTERVAL,
+    dwEffectWavesCount,
+    isTournament,
+    waveAcceleratorCard,
+    galaxyCompressorEffect,
+  } = props;
+
+  const DeathWavePermanence = (waves: number) => {
+    let waveCountDW = waves;
+    let totalWavesTime = 0;
+    while (waveCountDW > 0) {
+      totalWavesTime += getInGameWaveTime(waveAcceleratorCard, isTournament);
+      waveCountDW--;
+    }
+    const cdReductionTotal = totalWavesTime + packageCount * galaxyCompressorEffect;
+    const dwActivations = totalWavesTime / DW_COOLDOWN;
+    const dwUptime = dwActivations * DW_DURATION(dwEffectWavesCount, DEATH_WAVE_INTERVAL);
+
+    const adjustedUptimeDW = (cdReductionTotal / totalWavesTime) * dwUptime;
+    const baseUptimeDW = DW_COOLDOWN * dwActivations;
+    const isPermanentDW = adjustedUptimeDW >= baseUptimeDW;
+
+    return {
+      adjustedUptimeDW,
+      totalWavesTime,
+      isPermanentDW,
+    };
+  };
+
+  const DeathWaveStats = useMemo(() => {
+      return DeathWavePermanence(wavesToTest)
+    },
+    [
+      packageCount,
+      DW_COOLDOWN,
+      isTournament,
+      waveAcceleratorCard,
+      galaxyCompressorEffect,
+      dwEffectWavesCount,
+    ])
+
+  return (
+    <>
+      <p>DW:</p>
+      <p>Dur: {DW_DURATION(dwEffectWavesCount, DEATH_WAVE_INTERVAL)}</p>
+      <p>CD: {DW_COOLDOWN}</p>
+      <p>Wave Time: {DeathWaveStats.totalWavesTime.toLocaleString('en-US', { maximumSignificantDigits: 7 })}</p>
+      <p>Uptime: {DeathWaveStats.adjustedUptimeDW.toLocaleString('en-US', { maximumSignificantDigits: 7 })}</p>
+      <p>Perma?: {DeathWaveStats.isPermanentDW ? 'Yes' : 'No'}</p>
+    </>
+  );
+}

--- a/src/components/DeathWaveStats.tsx
+++ b/src/components/DeathWaveStats.tsx
@@ -29,11 +29,13 @@ export const DeathWaveStats = ({ props }) => {
     const adjustedUptimeDW = (cdReductionTotal / totalWavesTime) * dwUptime;
     const baseUptimeDW = DW_COOLDOWN * dwActivations;
     const isPermanentDW = adjustedUptimeDW >= baseUptimeDW;
+    const uptimePctDW = (adjustedUptimeDW / baseUptimeDW) * 100;
 
     return {
       adjustedUptimeDW,
       totalWavesTime,
       isPermanentDW,
+      uptimePctDW,
     };
   };
 
@@ -57,6 +59,7 @@ export const DeathWaveStats = ({ props }) => {
       <p>Wave Time: {DeathWaveStats.totalWavesTime.toLocaleString('en-US', { maximumSignificantDigits: 7 })}</p>
       <p>Uptime: {DeathWaveStats.adjustedUptimeDW.toLocaleString('en-US', { maximumSignificantDigits: 7 })}</p>
       <p>Perma?: {DeathWaveStats.isPermanentDW ? 'Yes' : 'No'}</p>
+      <p>Uptime: {DeathWaveStats.uptimePctDW.toLocaleString('en-US', { maximumSignificantDigits: 5 })}%</p>
     </>
   );
 }

--- a/src/components/GoldenTowerStats.tsx
+++ b/src/components/GoldenTowerStats.tsx
@@ -57,8 +57,8 @@ export const GoldenTowerStats = ({ props }) => {
       <p>GT:</p>
       <p>Dur: {GT_DURATION(gtDurationStonesLevel, gtDurationLabLevel, gtDurationSubstat)}</p>
       <p>CD: {GT_COOLDOWN}</p>
-      <p>Wave Time: {GoldenTowerStats.totalWavesTime.toLocaleString("en-US", { maximumSignificantDigits: 10 })}</p>
-      <p>Uptime: {GoldenTowerStats.adjustedUptimeGT.toLocaleString("en-US", { maximumSignificantDigits: 10 })}</p>
+      <p>Wave Time: {GoldenTowerStats.totalWavesTime.toLocaleString("en-US", { maximumSignificantDigits: 7 })}</p>
+      <p>Uptime: {GoldenTowerStats.adjustedUptimeGT.toLocaleString("en-US", { maximumSignificantDigits: 7 })}</p>
       <p>Perma?: {GoldenTowerStats.isPermanentGT ? 'Yes' : 'No'}</p>
     </>
   )

--- a/src/components/PermaCalculator.tsx
+++ b/src/components/PermaCalculator.tsx
@@ -7,7 +7,6 @@ import { BlackHoleStats } from './BlackHoleStats';
 import { DeathWaveStats } from './DeathWaveStats';
 
 const GT_DURATION_LAB: number[] = integerRange(0, 20);
-const BOSSWAVE_INTERVAL: number = 10;
 const WAVES_TO_TEST: number = 1000;
 const DEATH_WAVE_INTERVAL: number = 4;
 
@@ -24,6 +23,7 @@ export const PermaCalculator = ({ props }) => {
   const [bhDurationSubstat, setBHDurationSubstat] = useIntegerState(BLACK_HOLE_SUBSTATS_DURATION.None, 'bhDurationSubstat', 0, 4);
   const [bhPerk, setBHPerk] = useCheckboxState(true, 'bhPerk');
   const [isTournament, setIsTournament] = useCheckboxState(false, 'isTournament');
+  const [bossWaveInterval, setBossWaveInterval] = useIntegerState(10,'bossWaveInterval', 1, 10)
 
   const GT_DURATION = (gtDurationStonesLevel: number, gtDurationLabLevel: number, gtDurationSubstat: number): number | undefined => {
     return gtDurationStonesLevel + GT_DURATION_LAB[gtDurationLabLevel] + gtDurationSubstat;
@@ -46,7 +46,7 @@ export const PermaCalculator = ({ props }) => {
 
   const packageCheck = (wave: number): boolean => {
     let rollPackage = Math.floor(Math.random() * 100);
-    if (wave % BOSSWAVE_INTERVAL === 0) {
+    if (wave % bossWaveInterval === 0) {
       return true;
     } else if (packageChance === 0) {
       return false;
@@ -57,7 +57,7 @@ export const PermaCalculator = ({ props }) => {
 
   const rollPackagesForWaves = (waves: number): number => {
     if (packageChanceFixed) {
-      const bossWavePackages =  Math.floor(WAVES_TO_TEST / BOSSWAVE_INTERVAL);
+      const bossWavePackages =  Math.floor(WAVES_TO_TEST / bossWaveInterval);
       const fixedPackages = (waves - bossWavePackages) * packageChance / 100;
       return bossWavePackages + fixedPackages;
     }
@@ -72,12 +72,19 @@ export const PermaCalculator = ({ props }) => {
     return packageCount;
   };
 
-  packageCount = isTournament ? WAVES_TO_TEST : rollPackagesForWaves(WAVES_TO_TEST);
+  packageCount = rollPackagesForWaves(WAVES_TO_TEST);
 
   return (
     <div className='main'>
       <div className='controls'>
         <div className='controlGroup'>
+          <div className='control'>
+            <label>
+              Waves Per Boss
+              <select value={bossWaveInterval} onChange={setBossWaveInterval}>
+                {integerRange(1,10).map(waves => <option key={waves} value={waves}>{waves}</option> )}</select>
+            </label>
+          </div>
           <div className='control'>
             <label>
               Compressor

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -196,7 +196,8 @@ export const Main = () => {
             mnEnabled: MultiverseNexusEnabled,
             averageCooldownwithMN,
             gtEnabled,
-            bhEnabled,
+            dwEnabled,
+            bhEnabled
           }}
         />
       )}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -201,7 +201,7 @@ export const Main = () => {
           }}
         />
       )}
-      <p style={ { margin:'10px', fontSize:'smaller' } }>Inspired by Skye, created by Alypse. Thank you, Skye!</p>
+      <p style={ { margin:'10px', fontSize:'smaller', fontWeight:'bold' } }>Inspired by Skye, created by Alypse. Thank you, Skye!</p>
     </div>
   );
 };


### PR DESCRIPTION
Add statistics component for Death Wave (similar to the GT and BH stats components).

Ready for some user testing, so here's a deploy preview.

**Known issue: Changing package count isn't hitting the stats useMemo deps as expected.**

Noticed a lot of scope to DRY...that's next, specifically around permanence and time checks. 

